### PR TITLE
Create ECS cluster if missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,5 +6,7 @@ When responding to new requests, the agent should create or choose a folder whos
 
 Each example folder must include a `docker-compose.yml` so that running `docker-compose up --build` will start the example environment. The test scripts assume the corresponding compose service is already running.
 
-For completeness, examples should also include a separate folder demonstrating how to accomplish the same task in the IBM i PASE environment available on [PUB400.com](https://pub400.com/).
+### IBM i PASE (PUB400.com)
+
+Include a `pub400` subfolder **only** when the request specifically involves IBM i or IBM i PASE. AWS-focused examples should not contain a `pub400` folder.
 

--- a/github_actions_ecs/.github/workflows/deploy.yml
+++ b/github_actions_ecs/.github/workflows/deploy.yml
@@ -1,0 +1,84 @@
+name: Build and Deploy to ECS
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Show debug info
+        env:
+          DEPLOY_ENV: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
+        run: |
+          echo "GitHub ref: $GITHUB_REF"
+          echo "Deploy environment: $DEPLOY_ENV"
+          echo "AWS Region: $AWS_REGION"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Ensure ECS cluster exists
+        env:
+          CLUSTER: ${{ secrets.ECS_CLUSTER }}
+        run: |
+          if ! aws ecs describe-clusters --clusters "$CLUSTER" --region "$AWS_REGION" | grep -q 'clusterArn'; then
+            aws ecs create-cluster --cluster-name "$CLUSTER" --region "$AWS_REGION"
+          fi
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build and push image
+        env:
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+        run: |
+          IMAGE=$ECR_REPOSITORY:$(git rev-parse --short "$GITHUB_SHA")
+          docker build -t "$IMAGE" .
+          docker push "$IMAGE"
+          echo "image=$IMAGE" >> "$GITHUB_ENV"
+          echo "Built image $IMAGE"
+
+      - name: Ensure ECS service exists
+        env:
+          CLUSTER: ${{ secrets.ECS_CLUSTER }}
+          SERVICE_BASE: ${{ secrets.ECS_SERVICE_BASE }}
+          TASK_DEFINITION: ${{ secrets.TASK_DEFINITION }}
+          SUBNETS: ${{ secrets.ECS_SUBNETS }}
+          SECURITY_GROUPS: ${{ secrets.ECS_SECURITY_GROUPS }}
+          DEPLOY_ENV: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
+        run: |
+          SERVICE="$SERVICE_BASE-$DEPLOY_ENV"
+          if ! aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
+            --region "$AWS_REGION" | grep -q 'serviceArn'; then
+            aws ecs create-service --cluster "$CLUSTER" \
+              --service-name "$SERVICE" \
+              --task-definition "$TASK_DEFINITION" \
+              --desired-count 1 --launch-type FARGATE \
+              --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SECURITY_GROUPS],assignPublicIp=ENABLED}" \
+              --region "$AWS_REGION"
+          fi
+          echo "SERVICE=$SERVICE" >> "$GITHUB_ENV"
+
+      - name: Show ECS parameters
+        run: |
+          echo "Cluster: ${{ secrets.ECS_CLUSTER }}"
+          echo "Service: $SERVICE"
+          echo "Image: $IMAGE"
+
+      - name: Deploy to ECS
+        env:
+          CLUSTER: ${{ secrets.ECS_CLUSTER }}
+          SERVICE: ${{ env.SERVICE }}
+        run: |
+          aws ecs update-service --cluster "$CLUSTER" --service "$SERVICE" \
+            --force-new-deployment --region "$AWS_REGION"

--- a/github_actions_ecs/Dockerfile
+++ b/github_actions_ecs/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY app.py .
+CMD ["python", "app.py"]

--- a/github_actions_ecs/README.md
+++ b/github_actions_ecs/README.md
@@ -1,0 +1,33 @@
+# GitHub Actions ECS Deployment Example
+
+This example demonstrates a simple CI/CD pipeline using GitHub Actions to deploy a containerized application to AWS ECS.
+
+The `Dockerfile` builds a small Python web service. The GitHub Actions workflow builds the container image, pushes it to Amazon ECR, and updates an ECS service. Pushes to the **develop** branch deploy to the **dev** environment, while pushes to **main** deploy to **prod**. Create GitHub environments with these names to store your AWS credentials.
+
+## Usage (Docker)
+
+Build and start the sample service locally:
+
+```bash
+docker-compose up --build -d
+./run_tests.sh
+docker-compose down
+```
+
+## GitHub Actions
+
+The workflow file is located at `.github/workflows/deploy.yml`. Create GitHub environments named `dev` and `prod`, each containing these secrets:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION`
+- `ECR_REPOSITORY`
+- `ECS_CLUSTER`
+- `ECS_SERVICE_BASE` (the service name will be `<base>-dev` or `<base>-prod`)
+- `TASK_DEFINITION` (ARN or family name of the task definition to run)
+- `ECS_SUBNETS` (comma-separated subnet IDs)
+- `ECS_SECURITY_GROUPS` (comma-separated security group IDs)
+
+The workflow logs in to ECR, builds and pushes the Docker image, then ensures both the ECS cluster and service exist before deploying.
+If the cluster doesn't exist it will be created automatically, and the service will be created using the subnets and security groups you provide if needed.
+It also prints helpful debugging information such as the branch name, selected environment, and image tag so you can verify the pipeline configuration.

--- a/github_actions_ecs/app.py
+++ b/github_actions_ecs/app.py
@@ -1,0 +1,11 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"Hello from ECS")
+
+if __name__ == "__main__":
+    server = HTTPServer(("", 8000), Handler)
+    server.serve_forever()

--- a/github_actions_ecs/docker-compose.yml
+++ b/github_actions_ecs/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"

--- a/github_actions_ecs/run_tests.sh
+++ b/github_actions_ecs/run_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+# This script assumes docker-compose up -d is running
+sleep 2
+code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/)
+[ "$code" = "200" ]


### PR DESCRIPTION
## Summary
- ensure ECS cluster exists before pushing image and creating service
- document automatic cluster creation in README

## Testing
- `docker-compose up --build -d` *(fails: command not found)*
- `bash -x run_tests.sh` *(fails: curl couldn't connect to localhost)*
- `docker-compose down` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a4b2ebb708324aa75585df478baa8